### PR TITLE
feat: implemented event rethrowing

### DIFF
--- a/src/main/kotlin/com/msd/event/application/ErrorEvent.kt
+++ b/src/main/kotlin/com/msd/event/application/ErrorEvent.kt
@@ -1,0 +1,17 @@
+package com.msd.event.application
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@Entity
+class ErrorEvent(
+    val topic: String,
+    @Column(length = 2048)
+    val eventString: String,
+    val eventType: EventType
+) {
+    @Id
+    val errorId: UUID = UUID.randomUUID()
+}

--- a/src/main/kotlin/com/msd/event/application/EventRepository.kt
+++ b/src/main/kotlin/com/msd/event/application/EventRepository.kt
@@ -1,0 +1,6 @@
+package com.msd.event.application
+
+import org.springframework.data.repository.CrudRepository
+import java.util.*
+
+interface EventRepository : CrudRepository<ErrorEvent, UUID>

--- a/src/main/kotlin/com/msd/event/application/KafkaMessageProducer.kt
+++ b/src/main/kotlin/com/msd/event/application/KafkaMessageProducer.kt
@@ -2,14 +2,17 @@ package com.msd.event.application
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.msd.domain.DomainEvent
+import com.msd.event.application.dto.*
 import mu.KotlinLogging
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
 class KafkaMessageProducer(
     private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val eventRepository: EventRepository
 ) {
 
     private val logger = KotlinLogging.logger {}
@@ -30,8 +33,42 @@ class KafkaMessageProducer(
             },
             {
                 logger.error("Failed to send message")
-                // TODO add event send reattempt
+                val errorEvent = ErrorEvent(topic, jacksonObjectMapper().writeValueAsString(event), EventType.valueOf(event.type))
+                eventRepository.save(errorEvent)
             }
         )
+    }
+
+    /**
+     * Automatically resends all failed Events after a certain time. Events are saved automatically in `EventRepository` when
+     * there was a failure to send them. The DomainEvent will be serialized as a String and will therefore be deserialized
+     */
+    @Scheduled(initialDelay = 30000L, fixedDelay = 15000)
+    fun retryEvent() {
+        val events = eventRepository.findAll()
+        events.forEach {
+            val event = getDomainEventFromString(it.eventString, it.eventType)
+            send(it.topic, event)
+        }
+    }
+
+    /**
+     * Deserializes a given [DomainEvent] from a `String` and `EventType`.
+     *
+     * @return a `DomainEvent` with the proper `payload`
+     */
+    private fun getDomainEventFromString(payloadString: String, eventType: EventType): DomainEvent<GenericEventDTO> {
+        return when (eventType) {
+            EventType.PLANET_BLOCKED -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, BlockEventDTO::class.java))
+            EventType.MOVEMENT -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, MovementEventDTO::class.java))
+            EventType.ITEM_MOVEMENT -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, ItemMovementEventDTO::class.java))
+            EventType.ITEM_REPAIR -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, ItemRepairEventDTO::class.java))
+            EventType.REGENERATION -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, RegenerationEventDTO::class.java))
+            EventType.MINING -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, MiningEventDTO::class.java))
+            EventType.ITEM_FIGHTING -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, ItemFightingEventDTO::class.java))
+            EventType.FIGHTING -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, FightingEventDTO::class.java))
+            EventType.RESOURCE_DISTRIBUTION -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, ResourceDistributionEventDTO::class.java))
+            EventType.NEIGHBOURS -> jacksonObjectMapper().readValue(payloadString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, NeighboursEventDTO::class.java))
+        }
     }
 }

--- a/src/test/kotlin/com/msd/event/application/EventRepositoryTest.kt
+++ b/src/test/kotlin/com/msd/event/application/EventRepositoryTest.kt
@@ -1,0 +1,67 @@
+package com.msd.event.application
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.msd.domain.DomainEvent
+import com.msd.event.application.dto.BlockEventDTO
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles(profiles = ["test"])
+class EventRepositoryTest(
+    @Autowired private val eventRepository: EventRepository,
+    @Autowired private val topicConfig: ProducerTopicConfiguration
+) {
+
+    @Test
+    fun `saving and retrieving events works`() {
+        // given
+        val event = DomainEvent(
+            BlockEventDTO(true, "planet blocked", UUID.randomUUID(), 15),
+            EventType.PLANET_BLOCKED.eventString,
+            UUID.randomUUID().toString(),
+            1,
+            OffsetDateTime.now(ZoneOffset.UTC).toString()
+        )
+
+        val errorEvent = ErrorEvent(topicConfig.ROBOT_BLOCKED, jacksonObjectMapper().writeValueAsString(event), EventType.PLANET_BLOCKED)
+        eventRepository.save(errorEvent)
+
+        // when
+        val repoEvent = eventRepository.findByIdOrNull(errorEvent.errorId)!!
+        // then
+
+        val deserializedEvent = jacksonObjectMapper().readValue<DomainEvent<BlockEventDTO>>(repoEvent.eventString, jacksonObjectMapper().typeFactory.constructParametricType(DomainEvent::class.java, BlockEventDTO::class.java))
+        assertAll(
+            "assert retrieved event",
+            {
+                assertEquals(errorEvent.errorId, repoEvent.errorId)
+            },
+            {
+                assertEquals(errorEvent.topic, repoEvent.topic)
+            },
+            {
+                assertEquals(true, deserializedEvent.payload.success)
+            },
+            {
+                assertEquals("planet blocked", deserializedEvent.payload.message)
+            },
+            {
+                assertEquals(event.payload.planetId, deserializedEvent.payload.planetId)
+            },
+            {
+                assertEquals(event.payload.remainingEnergy, 15)
+            }
+        )
+    }
+}

--- a/src/test/kotlin/com/msd/event/application/KafkaMessageProducerTest.kt
+++ b/src/test/kotlin/com/msd/event/application/KafkaMessageProducerTest.kt
@@ -1,0 +1,65 @@
+package com.msd.event.application
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.msd.application.AbstractKafkaProducerTest
+import com.msd.domain.DomainEvent
+import com.msd.event.application.dto.BlockEventDTO
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@DirtiesContext
+@EmbeddedKafka(
+    partitions = 1,
+    brokerProperties = ["listeners=PLAINTEXT://\${spring.kafka.bootstrap-servers}", "port=9092"]
+)
+@Transactional
+@ActiveProfiles(profiles = ["test"])
+internal class KafkaMessageProducerTest(
+    @Autowired private val embeddedKafka: EmbeddedKafkaBroker,
+    @Autowired private val topicConfig: ProducerTopicConfiguration,
+    @Autowired private val eventRepository: EventRepository,
+    @Autowired private val kafkaMessageProducer: KafkaMessageProducer
+) : AbstractKafkaProducerTest(embeddedKafka, topicConfig) {
+
+    @Test
+    fun `when resending an Event an Event is send to the correct topic`() {
+        // given
+        startPlanetBlockedContainer()
+
+        val event = DomainEvent(
+            BlockEventDTO(true, "planet blocked", UUID.randomUUID(), 15),
+            EventType.PLANET_BLOCKED.eventString,
+            UUID.randomUUID().toString(),
+            1,
+            OffsetDateTime.now(ZoneOffset.UTC).toString()
+        )
+
+        val errorEvent = ErrorEvent(topicConfig.ROBOT_BLOCKED, jacksonObjectMapper().writeValueAsString(event), EventType.PLANET_BLOCKED)
+        eventRepository.save(errorEvent)
+        // when
+        kafkaMessageProducer.retryEvent()
+        // then
+        val singleRecord = consumerRecords.poll(100, TimeUnit.MILLISECONDS)
+        Assertions.assertNotNull(singleRecord!!)
+        Assertions.assertEquals(topicConfig.ROBOT_BLOCKED, singleRecord.topic())
+
+        val domainEvent = DomainEvent.build(
+            jacksonObjectMapper().readValue(singleRecord.value(), BlockEventDTO::class.java),
+            singleRecord.headers()
+        )
+        eventTestUtils.checkHeaders(UUID.fromString(event.transactionId), EventType.PLANET_BLOCKED, domainEvent)
+        eventTestUtils.checkBlockPayload(true, "planet blocked", event.payload.planetId, 15, domainEvent.payload)
+    }
+}


### PR DESCRIPTION
The Events are saved when they can't be sent. Because the Events have a generic payload they have to be serialized as a String when saved and deserialized to the proper type when retrieved from the repo.